### PR TITLE
wrap the language_term hash in an array

### DIFF
--- a/backend/model/repository_exporter.rb
+++ b/backend/model/repository_exporter.rb
@@ -12,11 +12,11 @@ class RepositorySerializer < ASpaceExport::Serializer
 
     unless mods.language_term.nil?
       language = mods.language_term.split(":")
-      record['language'] = {
+      record['language'] = [{
         'text' => language[0],
         'code' => language[1],
         'authority' => "iso639-2b"
-      }
+      }]
     end
 
     unless mods.dates.empty?


### PR DESCRIPTION
wraps the MODS language_term hash in an array object, only to be serialized in the JSON payload if a language is present on the source ArchivesSpace record 