### PR TITLE
add repository checker functionality

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,2 @@
+repository_menu_controller: repository_sync
+no_automatic_routes: true

--- a/frontend/assets/repository_sync.js
+++ b/frontend/assets/repository_sync.js
@@ -1,0 +1,13 @@
+function RepositoryCheck($repository_check_form) {
+  this.$repository_check_form = $repository_check_form;
+  this.setup_form();
+}
+
+RepositoryCheck.prototype.setup_form = function() {
+  var self = this;
+  $(document).trigger("loadedrecordsubforms.aspace", this.$repository_check_form);
+};
+
+$(document).ready(function() {
+  var repositoryCheck = new RepositoryCheck($("#repository_check_form"));
+});

--- a/frontend/controllers/repository_sync_controller.rb
+++ b/frontend/controllers/repository_sync_controller.rb
@@ -1,11 +1,53 @@
-class RepositorySyncController < ExportsController
+class RepositorySyncController < ApplicationController
 
-  set_access_control "view_repository" => [:download]
+  set_access_control "view_repository" => [:index, :search, :download]
 
   include ExportHelper
 
+  def index
+  end
+
+  def search
+    params['ref'] = params['item']['ref'] if params['ref'].nil?
+    @results = do_search(params)
+  end
+
   def download
     download_export("/repositories/#{JSONModel::repository}/archival_objects/#{params[:id]}/repository.xml")
+  end
+
+  private
+
+  def do_search(params)
+    ref = params['ref']
+    json = JSONModel::HTTP::get_json(ref)
+
+    results = {
+			'title' => json['title'],
+			'id' => json['component_id'],
+			'ref' => ref
+		}
+
+    json_uri = URI("#{JSONModel::HTTP.backend_url}#{ref}/repository")
+    json_response = HTTPRequest.new.get(json_uri)
+    if json_response.is_a?(Net::HTTPSuccess)
+      obj = JSON.parse(json_response.body)
+      results['json'] = JSON.pretty_generate(obj)
+    else
+      results['json'] = "An error occurred while fetching JSON."
+    end
+
+    mods_uri = URI("#{JSONModel::HTTP.backend_url}#{ref}/repository.xml")
+    mods_response = HTTPRequest.new.get(mods_uri)
+    if mods_response.is_a?(Net::HTTPSuccess)
+      xml = Nokogiri::XML(mods_response.body,&:noblanks)
+      mods = xml.at_css('mods')
+      results['mods'] = mods.to_xml(indent: 2)
+    else
+      results['mods'] = "An error occurred while fetching MODS XML."
+    end
+
+    results
   end
 
 end

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -1,4 +1,7 @@
 en:
   plugins:
-    ao_mods:
-      export: Export MODS
+    repository_sync:
+      label: Repository Checker
+      title: Repository Checker
+      actions:
+        search: Search

--- a/frontend/routes.rb
+++ b/frontend/routes.rb
@@ -1,3 +1,5 @@
 ArchivesSpace::Application.routes.draw do
+  match('/plugins/repository_sync' => 'repository_sync#index', :via => [:get])
+  match('/plugins/repository_sync/search' => 'repository_sync#search', :via => [:post])
   match('/plugins/repository_sync/:id/download' => 'repository_sync#download', :via => [:get])
 end

--- a/frontend/views/repository_sync/_form.html.erb
+++ b/frontend/views/repository_sync/_form.html.erb
@@ -1,0 +1,19 @@
+<div class="subrecord-form-dummy">
+  <h3>Check Item</h3>
+  <div class="subrecord-form-container">
+    <%= form_tag({:controller => :repository_sync, :action => :search}, {:class => "form-horizontal", :id => "repository_check_form"}) do |f| %>
+      <div class="form-group required">
+        <label class="control-label col-sm-2" for="resource">Item</label>
+        <div class="controls col-sm-8">
+          <%= render_aspace_partial :partial => "item_linker" %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div class="controls">
+          <%= submit_tag I18n.t("plugins.repository_sync.actions.search"), :class => "btn btn-primary pull-right" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/frontend/views/repository_sync/_item_linker.html.erb
+++ b/frontend/views/repository_sync/_item_linker.html.erb
@@ -1,0 +1,27 @@
+<%
+  if params['archival_object'].blank?
+   selected_json = "{}"
+  else
+   selected_json = params['archival_object']['_resolved']
+  end
+%>
+
+<div class="input-group linker-wrapper">
+  <input type="text" class="linker" id="item"
+         data-label="Item"
+         data-label_plural="Items"
+         data-name="ref"
+         data-path="item"
+         data-url="<%= url_for  :controller => :search, :action => :do_search, :format => :json %>"
+         data-browse-url="<%= url_for :controller => :search, :action => :do_search, :format => :js, :facets => [], :sort => "title_sort asc" %>"
+         data-selected="<%= selected_json %>"
+         data-multiplicity="one"
+         data-types='<%= ['archival_object'].to_json %>'
+  />
+  <div class="input-group-btn">
+    <a class="btn btn-default dropdown-toggle last" data-toggle="dropdown" href="javascript:void(0);"><span class="caret"></span></a>
+    <ul class="dropdown-menu">
+      <li><a href="javascript:void(0);" class="linker-browse-btn"><%= I18n.t("actions.browse") %></a></li>
+    </ul>
+  </div>
+</div>

--- a/frontend/views/repository_sync/_toolbar_button.html.erb
+++ b/frontend/views/repository_sync/_toolbar_button.html.erb
@@ -1,1 +1,0 @@
-<a href="<%= "#{AppConfig[:frontend_proxy_prefix]}plugins/repository_sync/#{params[:id]}/download"%>"><%= I18n.t("plugins.ao_mods.export") %></a>

--- a/frontend/views/repository_sync/index.html.erb
+++ b/frontend/views/repository_sync/index.html.erb
@@ -1,0 +1,14 @@
+<%= setup_context :title => I18n.t("plugins.repository_sync.title") %>
+
+<div class="record-pane">
+  <div class="row">
+    <div class="col-md-12">
+      <%= render_aspace_partial :partial => "shared/flash_messages" %>
+      <h2><%= I18n.t("plugins.repository_sync.title") %></h2>
+    </div>
+  </div>
+
+  <%= render_aspace_partial :partial => "form" %>
+</div>
+
+<script src="<%= "#{AppConfig[:frontend_prefix]}assets/repository_sync.js" %>"></script>

--- a/frontend/views/repository_sync/search.html.erb
+++ b/frontend/views/repository_sync/search.html.erb
@@ -1,0 +1,25 @@
+<%= setup_context :title => "#{@results['title']} (#{@results['id']})", :trail => [[I18n.t("plugins.repository_sync.title"), {:controller => :repository_sync, :action => :index}]] %>
+
+<div class="record-pane">
+  <div class="row">
+    <div class="col-md-12">
+      <%= render_aspace_partial :partial => "shared/flash_messages" %>
+      <h2><%= "#{@results['title']} (#{@results['id']})" %></h2>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-6">
+      <h4>JSON Object</h4>
+      <pre class="pre-scrollable"><code><%= @results['json'] %></code></pre>
+    </div>
+    <div class="col-md-6">
+      <h4>MODS XML Object</h4>
+      <pre class="pre-scrollable"><code><%= @results['mods'] %></code></pre>
+    </div>
+  </div>
+
+  <%= render_aspace_partial :partial => "form" %>
+</div>
+
+<script src="<%= "#{AppConfig[:frontend_prefix]}assets/repository_sync.js" %>"></script>


### PR DESCRIPTION
* adds a frontend plugin menu option for "Repository Checker"
* the user provides an item; Repository Checker will display both the repository JSON object and the MODS XML side-by-side
* this update removes the user's ability to download a MODS XML representation of an item from the component toolbar