### PR TITLE
refactor plugin to fetch parts list from the digital object component tree

### DIFF
--- a/backend/controllers/repository_sync.rb
+++ b/backend/controllers/repository_sync.rb
@@ -7,7 +7,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "OK"]) \
   do
-    obj = resolve_references(ArchivalObject.to_jsonmodel(params[:id]), ['linked_agents', 'subjects', 'digital_object'])
+    obj = resolve_references(ArchivalObject.to_jsonmodel(params[:id]), ['linked_agents', 'subjects', 'digital_object', 'digital_object::tree'])
     json = ASpaceExport.model(:repository).from_archival_object(JSONModel(:archival_object).new(obj))
 
     json_response(ASpaceExport::serialize(json))
@@ -20,7 +20,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "OK"]) \
   do
-    obj = resolve_references(ArchivalObject.to_jsonmodel(params[:id]), ['linked_agents', 'subjects', 'digital_object'])
+    obj = resolve_references(ArchivalObject.to_jsonmodel(params[:id]), ['linked_agents', 'subjects', 'digital_object', 'digital_object::tree'])
     mods = ASpaceExport.model(:repository_mods).from_archival_object(JSONModel(:archival_object).new(obj))
 
     xml_response(ASpaceExport::serialize(mods))

--- a/backend/controllers/repository_sync.rb
+++ b/backend/controllers/repository_sync.rb
@@ -7,7 +7,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "OK"]) \
   do
-    obj = resolve_references(ArchivalObject.to_jsonmodel(params[:id]), ['repository::agent_representation', 'linked_agents', 'subjects', 'digital_object'])
+    obj = resolve_references(ArchivalObject.to_jsonmodel(params[:id]), ['linked_agents', 'subjects', 'digital_object'])
     json = ASpaceExport.model(:repository).from_archival_object(JSONModel(:archival_object).new(obj))
 
     json_response(ASpaceExport::serialize(json))
@@ -20,7 +20,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "OK"]) \
   do
-    obj = resolve_references(ArchivalObject.to_jsonmodel(params[:id]), ['repository::agent_representation', 'linked_agents', 'subjects', 'digital_object'])
+    obj = resolve_references(ArchivalObject.to_jsonmodel(params[:id]), ['linked_agents', 'subjects', 'digital_object'])
     mods = ASpaceExport.model(:repository_mods).from_archival_object(JSONModel(:archival_object).new(obj))
 
     xml_response(ASpaceExport::serialize(mods))
@@ -43,7 +43,7 @@ class ArchivesSpaceService < Sinatra::Base
     .permissions([:view_repository])
     .returns([200, "OK"]) \
   do
-    obj = resolve_references(Resource.to_jsonmodel(params[:id]), ['repository::agent_representation', 'linked_agents', 'subjects', 'digital_object'])
+    obj = resolve_references(Resource.to_jsonmodel(params[:id]), ['linked_agents', 'subjects', 'digital_object'])
     json = ASpaceExport.model(:repository).from_resource(JSONModel(:resource).new(obj))
 
     json_response(ASpaceExport::serialize(json))

--- a/frontend/controllers/repository_sync_controller.rb
+++ b/frontend/controllers/repository_sync_controller.rb
@@ -8,8 +8,13 @@ class RepositorySyncController < ApplicationController
   end
 
   def search
-    params['ref'] = params['item']['ref'] if params['ref'].nil?
-    @results = do_search(params)
+    if params['item'].nil?
+      flash[:error] = "No item selected"
+      redirect_to :action => :index
+    else
+      params['ref'] = params['item']['ref'] if params['ref'].nil?
+      @results = do_search(params)
+    end
   end
 
   def download


### PR DESCRIPTION
Old behavior: Digital objects contained no components and multiple file versions; one version per file comprising the object
New behavior: Digital objects contain one component per constituent file; each component contains one file version, representing the file itself, identified by its file name and containing the file format and optional caption 