### PR TITLE
get parts.type to use mime_type_map

### DIFF
--- a/backend/model/repository_model.rb
+++ b/backend/model/repository_model.rb
@@ -212,7 +212,7 @@ class RepositoryModel < ASpaceExport::ExportModel
 
           unless child['file_versions'].nil? || child['file_versions'].empty?
             file = child['file_versions'].first
-            part['type'] = file['file_format_name']
+            part['type'] = self.class.mime_type_map[file['file_format_name']]
             part['caption'] = file['caption']
           end
 


### PR DESCRIPTION
get parts.type to use mime_type_map, addresses issue of tiff instead of image/tiff in metadata